### PR TITLE
Prevent start game input from also firing on scene transition

### DIFF
--- a/Assets/Scripts/AsteroidGame/PlayerScripts/PlayerFiringHandler.cs
+++ b/Assets/Scripts/AsteroidGame/PlayerScripts/PlayerFiringHandler.cs
@@ -57,13 +57,13 @@ namespace AsteroidGame.PlayerScripts
         
         private void RemoveThrottleOnFiringFromSceneTransition()
         {
-            _gameState.IsGameStarting
-                .Throttle(TimeSpan.FromSeconds(_settings.sceneTransitionDelay))
-                .Subscribe(isGameStarting =>
+            _gameState.IsFiringEnabled
+                .Throttle(TimeSpan.FromSeconds(_settings.firingEnabledDelay))
+                .Subscribe(isFiringEnabled =>
                 {
-                    if (isGameStarting)
+                    if (!isFiringEnabled)
                     {
-                        _gameState.IsGameStarting.Value = false;
+                        _gameState.IsFiringEnabled.Value = true;
                     }
                 })
                 .AddTo(_disposables);
@@ -73,7 +73,7 @@ namespace AsteroidGame.PlayerScripts
         {
             _inputState.IsFiring.Subscribe(hasFired =>
             {
-                if (hasFired && !_player.IsDead && !_firingDisabled && !_gameState.IsGameStarting.Value)
+                if (hasFired && !_player.IsDead && !_firingDisabled && _gameState.IsFiringEnabled.Value)
                 {
                     FireProjectileBullets();
                     _firingDisabled = true;
@@ -111,7 +111,7 @@ namespace AsteroidGame.PlayerScripts
             public float fireCooldown;
             public float projectileSpeed;
             public float projectileLifespan;
-            public float sceneTransitionDelay;
+            public float firingEnabledDelay;
         }
 
         

--- a/Assets/Scripts/ProjectScripts/GameSetupInit.cs
+++ b/Assets/Scripts/ProjectScripts/GameSetupInit.cs
@@ -27,7 +27,7 @@ namespace ProjectScripts
             _gameState.CurrentLevel = new ReactiveProperty<int>(0);
             _gameState.Score = new ReactiveProperty<int>(0);
 
-            _gameState.IsGameStarting = new ReactiveProperty<bool>(false);
+            _gameState.IsFiringEnabled = new ReactiveProperty<bool>(false);
             _gameState.IsGameRunning = new ReactiveProperty<bool>(false);
             _gameState.IsGameReset = new ReactiveProperty<bool>(false);
 

--- a/Assets/Scripts/ProjectScripts/GameState.cs
+++ b/Assets/Scripts/ProjectScripts/GameState.cs
@@ -19,7 +19,7 @@ namespace ProjectScripts
         public ReactiveProperty<int> CurrentLevel { get; set; }
         public ReactiveProperty<int> Score { get; set; }
         
-        public ReactiveProperty<bool> IsGameStarting { get; set; }
+        public ReactiveProperty<bool> IsFiringEnabled { get; set; }
         public ReactiveProperty<bool> IsGameRunning { get; set; }
         public ReactiveProperty<bool> IsGameReset { get; set; }
         

--- a/Assets/Scripts/StartMenuScripts/Misc/LoadAsteroidScene.cs
+++ b/Assets/Scripts/StartMenuScripts/Misc/LoadAsteroidScene.cs
@@ -31,8 +31,6 @@ namespace StartMenuScripts.Misc
                     if (isGameRunning)
                     {
                         _disposables.Clear();
-
-                        _gameState.IsGameStarting.Value = true;
                         
                         SceneManager.LoadScene("AsteroidGame");
                     }

--- a/Assets/Scripts/StartMenuScripts/Misc/SetupAsteroidData.cs
+++ b/Assets/Scripts/StartMenuScripts/Misc/SetupAsteroidData.cs
@@ -47,6 +47,7 @@ namespace StartMenuScripts.Misc
                         _gameState.CurrentLevel.Value = 0;
                         _gameState.Score.Value = 0;
                         
+                        _gameState.IsFiringEnabled.Value = false;
                         _gameState.IsGameReset.Value = false;
                     }
                 })


### PR DESCRIPTION
"Firing" on the start menu would both start the game, and fire a bullet immediately in the AsteroidGame scene. Added a gameState to impose a transition state where input to fire the projectile would be ignored.