### PR TITLE
Was passing the wrong objectsType for small ufo spawn

### DIFF
--- a/Assets/Scripts/AsteroidGame/Installers/GameInstaller.cs
+++ b/Assets/Scripts/AsteroidGame/Installers/GameInstaller.cs
@@ -18,6 +18,7 @@ namespace AsteroidGame.Installers
         {
             Container.BindInterfacesAndSelfTo<AsteroidSpawner>().AsSingle();
             Container.BindInterfacesAndSelfTo<UfoSpawner>().AsSingle();
+            Container.BindInterfacesTo<UfoSpawnInit>().AsSingle();
 
             Container.BindInterfacesAndSelfTo<GameLevelHandler>().AsSingle();
             

--- a/Assets/Scripts/AsteroidGame/Misc/UfoSpawnInit.cs
+++ b/Assets/Scripts/AsteroidGame/Misc/UfoSpawnInit.cs
@@ -1,0 +1,41 @@
+using ProjectScripts;
+using UniRx;
+using Zenject;
+
+namespace AsteroidGame.Misc
+{
+    public class UfoSpawnInit : IInitializable
+    {
+        private readonly GameState _gameState;
+        
+        private readonly CompositeDisposable _disposables = new CompositeDisposable();
+
+        public UfoSpawnInit(
+            GameState gameState)
+        {
+            _gameState = gameState;
+        }
+        
+        public void Initialize()
+        {
+            EnableUfoSpawnerTimedSpawn();
+        }
+
+        private void EnableUfoSpawnerTimedSpawn()
+        {
+            _gameState.IsGameRunning
+                .Subscribe(isGameRunning =>
+                {
+                    if (isGameRunning)
+                    {
+                        _gameState.IsUfoSpawning.Value = true;
+                    }
+                    else
+                    {
+                        _disposables?.Clear();
+                    }
+                })
+                .AddTo(_disposables);
+        }
+    }
+}

--- a/Assets/Scripts/AsteroidGame/Misc/UfoSpawnInit.cs.meta
+++ b/Assets/Scripts/AsteroidGame/Misc/UfoSpawnInit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4edd9add8a3224019b5691583461a6c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AsteroidGame/Misc/UfoSpawner.cs
+++ b/Assets/Scripts/AsteroidGame/Misc/UfoSpawner.cs
@@ -31,6 +31,8 @@ namespace AsteroidGame.Misc
 
         private IDisposable _ufoSpawnTimer;
         private IDisposable _ufoBoundTimer;
+
+        private bool _isInitialized;
         
         private readonly CompositeDisposable _disposables = new CompositeDisposable();
 
@@ -50,15 +52,19 @@ namespace AsteroidGame.Misc
 
         public void Initialize()
         {
+            UpdateUfoSpawnBounds();
+            
             OnlySpawnUfoDuringTheGame();
+
+            DisposeIfGameNotRunning();
         }
 
         private void OnlySpawnUfoDuringTheGame()
         {
-            _gameState.IsGameRunning
-                .Subscribe(isGameRunning =>
+            _gameState.IsUfoSpawning
+                .Subscribe(isUfoSpawning =>
                 {
-                    if (isGameRunning)
+                    if (isUfoSpawning)
                     {
                         var difficulties = _difficultySettings.difficulties[_gameState.GameDifficulty.Value];
             
@@ -73,14 +79,14 @@ namespace AsteroidGame.Misc
 
                         _ufoMinSpawnDelay = difficulties.ufoMinSpawnDelay;
                         _ufoMaxSpawnDelay = difficulties.ufoMaxSpawnDelay;
-            
+                        
                         DelayForATimeThenSpawnUfo(ObjectTypes.LargeUfo);
 
                         TrackLevelChangeToSwitchToSmallUfo();
-                
-                        UpdateUfoSpawnBounds();
-
-                        DisposeIfGameNotRunning();
+                    }
+                    else
+                    {
+                        _disposables.Clear();
                     }
                 })
                 .AddTo(_disposables);
@@ -208,8 +214,6 @@ namespace AsteroidGame.Misc
                 {
                     if (!isGameRunning)
                     {
-                        _ufoSpawnTimer?.Dispose();
-                        _ufoBoundTimer?.Dispose();
                         _disposables?.Clear();
                     }
                 })

--- a/Assets/Scripts/AsteroidGame/Misc/UfoSpawner.cs
+++ b/Assets/Scripts/AsteroidGame/Misc/UfoSpawner.cs
@@ -84,10 +84,6 @@ namespace AsteroidGame.Misc
 
                         TrackLevelChangeToSwitchToSmallUfo();
                     }
-                    else
-                    {
-                        _disposables.Clear();
-                    }
                 })
                 .AddTo(_disposables);
         }

--- a/Assets/Scripts/AsteroidGame/Misc/UfoSpawner.cs
+++ b/Assets/Scripts/AsteroidGame/Misc/UfoSpawner.cs
@@ -117,7 +117,7 @@ namespace AsteroidGame.Misc
             if (level == _smallUfoLevelToSpawn)
             {
                 _ufoSpawnTimer?.Dispose();
-                DelayForATimeThenSpawnUfo(ObjectTypes.SmallAsteroid);
+                DelayForATimeThenSpawnUfo(ObjectTypes.SmallUfo);
             }
         }
 

--- a/Assets/Scripts/ProjectScripts/GameSetupInit.cs
+++ b/Assets/Scripts/ProjectScripts/GameSetupInit.cs
@@ -31,6 +31,8 @@ namespace ProjectScripts
             _gameState.IsGameRunning = new ReactiveProperty<bool>(false);
             _gameState.IsGameReset = new ReactiveProperty<bool>(false);
 
+            _gameState.IsUfoSpawning = new ReactiveProperty<bool>(false);
+
             _inputState.IsHyperspaceActive = new ReactiveProperty<bool>(false);
             _inputState.IsFiring = new ReactiveProperty<bool>(false);
 

--- a/Assets/Scripts/ProjectScripts/GameState.cs
+++ b/Assets/Scripts/ProjectScripts/GameState.cs
@@ -23,7 +23,7 @@ namespace ProjectScripts
         public ReactiveProperty<bool> IsGameRunning { get; set; }
         public ReactiveProperty<bool> IsGameReset { get; set; }
         
-        
+        public ReactiveProperty<bool> IsUfoSpawning { get; set; }
         
         public ReactiveProperty<int> GameDifficulty { get; set; }
         public  ReactiveProperty<int> GameMode { get; set; }

--- a/Assets/Scripts/StartMenuScripts/Misc/SetupAsteroidData.cs
+++ b/Assets/Scripts/StartMenuScripts/Misc/SetupAsteroidData.cs
@@ -49,6 +49,7 @@ namespace StartMenuScripts.Misc
                         
                         _gameState.IsFiringEnabled.Value = false;
                         _gameState.IsGameReset.Value = false;
+                        _gameState.IsUfoSpawning.Value = false;
                     }
                 })
                 .AddTo(_disposables);


### PR DESCRIPTION
UfoSpawner in AsteroidGame scene triggered two timers to spawn the same ufo from the memory pool stack, resulting in a null error when the second timer attempted to Create(). The spawner is initialized at load, so it was notified on its .Subscribe() in both scenes, causing the double trigger.